### PR TITLE
send_request modified to read proxy settings from the environment

### DIFF
--- a/lib/openweather2/client.rb
+++ b/lib/openweather2/client.rb
@@ -53,8 +53,9 @@ module Openweather2
 
   def send_request(uri)
     req = Net::HTTP::Get.new(uri.request_uri)
-    http_params = [uri.hostname, uri.port, use_ssl: uri.scheme == 'https']
-    Net::HTTP.start(*http_params) {|http| http.request(req)}
+    httpSession = Net::HTTP.new(uri.hostname, uri.port)
+    httpSession.use_ssl = uri.scheme == 'https'
+    httpSession.start() { |http| http.request(req) }
   end
 
   def set_params(options)


### PR DESCRIPTION
@lucasocon : I fixed the send_request method since it could not read the proxy settings from the environment. The reason was that the method used the start method to create an HTTP session instance, which , in contrast to the new method, sets the proxy arg to nil disabling so reading the proxy params from the environment.